### PR TITLE
getOrderedValue() should be public

### DIFF
--- a/src/org/vaadin/tepi/listbuilder/ListBuilder.java
+++ b/src/org/vaadin/tepi/listbuilder/ListBuilder.java
@@ -393,7 +393,7 @@ public class ListBuilder extends AbstractSelect {
         }
     }
 
-    private ArrayList<Object> getOrderedValue() {
+    public ArrayList<Object> getOrderedValue() {
         ArrayList<Object> retVal = new ArrayList<Object>();
         for (String key : orderedValue) {
             retVal.add(itemIdMapper.get(key));


### PR DESCRIPTION
Currently getValue() does not return selected items in the correct order. The workaround is to call getOrderedValue(), but first it has to be made public
